### PR TITLE
work around plugin test failures

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,7 +20,7 @@ web = http://github.com/chiselwright/%s/issues
 ; order can matter!
 [PodWeaver]
 
-[ContributorsFromGit]
+[Git::Contributors]
 
 [@Git]
 allow_dirty = README.mkdn


### PR DESCRIPTION
I wrote a new implementation of the contributors-from-git plugin 3 years ago to work around the installation issues I found.